### PR TITLE
Fixing an issue relating to resuming MCMC fitting iterations.

### DIFF
--- a/dysmalpy/fitting/mcmc.py
+++ b/dysmalpy/fitting/mcmc.py
@@ -500,7 +500,9 @@ def _fit_emcee_221(gal, **kwargs ):
     start = time.time()
 
     if sampler.chain.shape[1] > 0:
-        logger.info('\n   Resuming with existing sampler chain'+'\n')
+        logger.info('\n   Resuming with existing sampler chain at iteration ' + 
+                    str(sampler.iteration) + '\n')
+        pos = sampler['chain'][:,-1,:]
 
     # --------------------------------
     # Run sampler: output info at each step


### PR DESCRIPTION
I have been trying to run the MCMC fitting in chunks of iterations so that the memory usage per chunk can be suitable for some high-performance clusters (with memory limit about 100 GB). 

In order to make it work, it seems that we need to fix a line of code to allow the MCMC fitting correctly resume from previous runs. It's in the MCMC fitting function and is about loading the `pos` variable from the last sample. 

It has been tested working with emcee 3.

_[Below are less important.]_
Maybe for those who are interested, my example approach of running the MCMC fitting in chunks is as follows:
a) first prepare the param file and data dir;
b) then copy the param file e.g. as "run_1.params" and modify the MCMC "nSteps" to 50 and "overwrite" to True in the copied param file;
c) then run dysmalpy to process the "run_1.params";
d) move all output files to a subdirectory named like "outdir_1", but keep the "*_sampler.h5";
e) then copy the original param file e.g. as "run_2.params" and modify the MCMC "nSteps" to 100 and "overwrite" to False in the copied param file;
f) repeat c-e steps by increasing "nSteps" to whatever we want, e.g., 1000. 
In this way, we can have a long MCMC chain without having too large memory usage. Otherwise if we run a long MCMC chain in a single execution, the memory usage can grow over 500 GB for a cube of about 80x80x80 size with lensing module on (meaning that a source-plane cube, e.g. 200x200x80-size, needs to say in the memory), 7-9 free parameters and for more than about 200 steps. 

