### PR TITLE
Migrate `model_key_re` -> more general `model_aperture_r`

### DIFF
--- a/dysmalpy/config.py
+++ b/dysmalpy/config.py
@@ -14,6 +14,18 @@ import numpy as np
 import astropy.units as u
 
 
+def _model_aperture_r(model, model_key_re = ['disk+bulge','r_eff_disk']):
+    # Default: use old behavior of model_key_re = ['disk+bulge','r_eff_disk']:
+
+    comp = model.components.__getitem__(model_key_re[0])
+    param_i = comp.param_names.index(model_key_re[1])
+    r_eff = comp.parameters[param_i]
+
+    return r_eff
+
+
+
+
 class ConfigBase:
     """
     Base class to handle settings for different functions.
@@ -119,6 +131,14 @@ class ConfigFitBase(ConfigBase):
     def __init__(self, **kwargs):
         super(ConfigFitBase, self).__init__(**kwargs)
 
+
+    def fill_values(self, **kwargs):
+        super(ConfigFitBase, self).fill_values(**kwargs)
+        # Backwards compatibility:
+        if (('model_key_re' in kwargs.keys()) & ('model_aperture_r' not in kwargs.keys()) \
+            & ('model_key_re' not in self.__dict__.keys())):
+            self.model_aperture_r = (lambda modelset: _model_aperture_r(modelset, model_key_re=self.model_key_re))
+
     def set_defaults(self):
         # Fitting defaults that are shared between all fitting methods
 
@@ -128,7 +148,7 @@ class ConfigFitBase(ConfigBase):
 
         self.blob_name = None
 
-        self.model_key_re = ['disk+bulge','r_eff_disk']
+        self.model_aperture_r = _model_aperture_r
         self.model_key_halo=['halo']
 
         self.save_model = True

--- a/dysmalpy/fitting/base.py
+++ b/dysmalpy/fitting/base.py
@@ -13,6 +13,7 @@ import six
 
 # DYSMALPY code
 from dysmalpy import plotting
+from dysmalpy import config
 from dysmalpy import utils_io as dpy_utils_io
 from dysmalpy.data_io import ensure_dir, load_pickle, dump_pickle
 
@@ -123,16 +124,14 @@ class FitResults(object):
         if filename is not None:
             dump_pickle(self, filename=filename, overwrite=overwrite)  # Save FitResults class to a pickle file
 
-    def save_bestfit_vel_ascii(self, gal, filename=None, model_key_re=['disk+bulge', 'r_eff_disk'], overwrite=False):
+    def save_bestfit_vel_ascii(self, gal, filename=None,
+                               model_aperture_r=config._model_aperture_r, overwrite=False):
         if filename is not None:
             try:
-                # RE needs to be in kpc
-                comp = gal.model.components.__getitem__(model_key_re[0])
-                param_i = comp.param_names.index(model_key_re[1])
-                r_eff = comp.parameters[param_i]
+                r_ap = model_aperture_r(self)
             except:
-                r_eff = 10. / 3.
-            rmax = np.max([3. * r_eff, 10.])
+                r_ap = 10./3.
+            rmax = np.max([3. * r_ap, 10.])
             stepsize = 0.1  # stepsize 0.1 kpc
             r = np.arange(0., rmax + stepsize, stepsize)
 

--- a/dysmalpy/fitting/mpfit.py
+++ b/dysmalpy/fitting/mpfit.py
@@ -226,7 +226,7 @@ def fit_mpfit(gal, **kwargs):
                                 f_results=kwargs_fit['f_results'],
                                 blob_name=kwargs_fit['blob_name'])
 
-    mpfitResults.input_results(m, gal=gal, model_key_re=kwargs_fit['model_key_re'],
+    mpfitResults.input_results(m, gal=gal, model_aperture_r=kwargs_fit['model_aperture_r'],
                     model_key_halo=kwargs_fit['model_key_halo'])
 
     #####
@@ -283,15 +283,15 @@ class MPFITResults(FitResults):
                     self.__dict__['bestfit_redchisq_{}'.format(k)] = chisq_red_per_type(gal, type=k)
 
 
-        # Get vmax and vrot
-        if kwargs_fit['model_key_re'] is not None:
-            if kwargs_fit['model_key_re'][0] in gal.model.components.keys():
-                comp = gal.model.components.__getitem__(kwargs_fit['model_key_re'][0])
-                param_i = comp.param_names.index(kwargs_fit['model_key_re'][1])
-                r_eff = comp.parameters[param_i]
-                self.vrot_bestfit = gal.model.velocity_profile(1.38 * r_eff, compute_dm=False)
-            else:
-                self.vrot_bestfit = np.NaN
+        # # Get vmax and vrot
+        # if kwargs_fit['model_aperture_r'] is not None:
+        #     if kwargs_fit['model_key_re'][0] in gal.model.components.keys():
+        #         comp = gal.model.components.__getitem__(kwargs_fit['model_key_re'][0])
+        #         param_i = comp.param_names.index(kwargs_fit['model_key_re'][1])
+        #         r_eff = comp.parameters[param_i]
+        #     r_ap = model_aperture_r(self)
+        #     #self.vrot_bestfit = gal.model.velocity_profile(1.38 * r_eff, compute_dm=False)
+        #     self.vrot_bestfit = gal.model.velocity_profile(r_ap, compute_dm=False)
 
         self.vmax_bestfit = gal.model.get_vmax()
 
@@ -321,7 +321,7 @@ class MPFITResults(FitResults):
         # Save velocity / other profiles to ascii file:
         if kwargs_fit['f_vel_ascii'] is not None:
             self.save_bestfit_vel_ascii(gal, filename=kwargs_fit['f_vel_ascii'],
-                    model_key_re=kwargs_fit['model_key_re'], overwrite=kwargs_fit['overwrite'])
+                    model_aperture_r=kwargs_fit['model_aperture_r'], overwrite=kwargs_fit['overwrite'])
 
         if (kwargs_fit['f_vcirc_ascii'] is not None) or (kwargs_fit['f_mass_ascii'] is not None):
             self.save_bestfit_vcirc_mass_profiles(gal, outpath=kwargs_fit['outdir'],
@@ -330,7 +330,7 @@ class MPFITResults(FitResults):
 
 
     def input_results(self, mpfit_obj, gal=None,
-                    model_key_re=None, model_key_halo=None):
+                    model_aperture_r=None, model_key_halo=None):
         """
         Save the best fit results from MPFIT in the MPFITResults object
         """
@@ -361,7 +361,7 @@ class MPFITResults(FitResults):
 
             for blobn in blob_names:
                 if blobn.lower() == 'fdm':
-                    param_bestfit = gal.model.get_dm_frac_effrad(model_key_re=model_key_re)
+                    param_bestfit = gal.model.get_dm_frac_effrad(model_aperture_r=model_aperture_r)
                 elif blobn.lower() == 'mvirial':
                     param_bestfit = gal.model.get_mvirial(model_key_halo=model_key_halo)
                 elif blobn.lower() == 'alpha':

--- a/dysmalpy/fitting_wrappers/setup_gal_models.py
+++ b/dysmalpy/fitting_wrappers/setup_gal_models.py
@@ -13,6 +13,7 @@ from dysmalpy import parameters
 from dysmalpy import fitting
 from dysmalpy import galaxy, instrument, models
 from dysmalpy import aperture_classes
+from dysmalpy import config
 
 try:
     import tied_functions, data_io
@@ -1634,10 +1635,8 @@ def setup_mcmc_dict(params=None, ndim_data=None):
         mcmc_dict['linked_posterior_names'] = None
 
 
-    #
-    mcmc_dict['model_key_re'] = ['disk+bulge', 'r_eff_disk']
+    mcmc_dict['model_aperture_r'] = config._model_aperture_r
     mcmc_dict['model_key_halo'] = ['halo']
-
 
     if 'continue_steps' not in mcmc_dict.keys():
         mcmc_dict['continue_steps'] = False

--- a/dysmalpy/fitting_wrappers/tied_functions.py
+++ b/dysmalpy/fitting_wrappers/tied_functions.py
@@ -214,8 +214,6 @@ def tied_mhalo_mstar_fixed_lmstar(model_set):
 
 ############################################################################
 # Tied functions for halo fitting:
-def tie_lmvirial_NFW(model_set):
-    return tie_lmvirial_to_fdm(model_set)
 
 # def tie_lmvirial_to_fdm(model_set):
 #     comp_halo = model_set.components.__getitem__('halo')
@@ -234,6 +232,9 @@ def tie_lmvirial_NFW(model_set):
 #     return alpha
 #
 
+def tie_lmvirial_NFW(model_set):
+    return tie_lmvirial_to_fdm(model_set)
+    
 def tie_lmvirial_to_fdm(model_set):
     comp_halo = None
     comps_bar = []

--- a/dysmalpy/models/kinematic_options.py
+++ b/dysmalpy/models/kinematic_options.py
@@ -18,6 +18,7 @@ import scipy.optimize as scp_opt
 # Local imports
 from .baryons import DiskBulge, LinearDiskBulge, Sersic, ExpDisk
 
+from dysmalpy import config
 
 __all__ = ['KinematicOptions']
 
@@ -117,157 +118,9 @@ class KinematicOptions:
         self.pressure_support_type = pressure_support_type
 
 
-    # def apply_adiabatic_contract(self, model, r, vbaryon, vhalo,
-    #                              compute_dm=False,
-    #                              model_key_re=['disk+bulge', 'r_eff_disk'],
-    #                              step1d = 0.2):
-    #     """
-    #     Function that applies adiabatic contraction to a ModelSet
-    #
-    #     Parameters
-    #     ----------
-    #     model : `ModelSet`
-    #         ModelSet that adiabatic contraction will be applied to
-    #
-    #     r : array
-    #         Radii in kpc
-    #
-    #     vbaryon : array
-    #         Baryonic component circular velocities in km/s
-    #
-    #     vhalo : array
-    #         Dark matter halo circular velocities in km/s
-    #
-    #     compute_dm : bool
-    #         If True, will return the adiabatically contracted halo velocities.
-    #
-    #     model_key_re : list
-    #         Two element list which contains the name of the model component
-    #         and parameter to use for the effective radius.
-    #         Default is ['disk+bulge', 'r_eff_disk'].
-    #
-    #     step1d : float
-    #         Step size in kpc to use during adiabatic contraction calculation
-    #
-    #     Returns
-    #     -------
-    #     vel : array
-    #        Total circular velocity corrected for adiabatic contraction in km/s
-    #
-    #     vhalo_adi : array
-    #         Dark matter halo circular velocities corrected for adiabatic contraction.
-    #         Only returned if `compute_dm` = True
-    #     """
-    #
-    #     if self.adiabatic_contract:
-    #         #logger.info("Applying adiabatic contraction.")
-    #
-    #         # Define 1d radius array for calculation
-    #         #step1d = 0.2  # kpc
-    #         # r1d = np.arange(step1d, np.ceil(r.max()/step1d)*step1d+ step1d, step1d, dtype=np.float64)
-    #         try:
-    #             rmaxin = r.max()
-    #         except:
-    #             rmaxin = r
-    #         # Get reff:
-    #         comp = model.components.__getitem__(model_key_re[0])
-    #         param_i = comp.param_names.index(model_key_re[1])
-    #         r_eff = comp.parameters[param_i]
-    #
-    #         rmax_calc = max(5.* r_eff, rmaxin)
-    #
-    #         # Wide enough radius range for full calculation -- out to 5*Reff, at least
-    #         r1d = np.arange(step1d, np.ceil(rmax_calc/step1d)*step1d+ step1d, step1d, dtype=np.float64)
-    #
-    #
-    #         rprime_all_1d = np.zeros(len(r1d))
-    #
-    #         # Calculate vhalo, vbaryon on this 1D radius array [note r is a 3D array]
-    #         vhalo1d = r1d * 0.
-    #         vbaryon1d = r1d * 0.
-    #         for cmp in model.mass_components:
-    #
-    #             if model.mass_components[cmp]:
-    #                 mcomp = model.components[cmp]
-    #                 if isinstance(mcomp, DiskBulge) | isinstance(mcomp, LinearDiskBulge):
-    #                     cmpnt_v = mcomp.circular_velocity(r1d)
-    #                 else:
-    #                     cmpnt_v = mcomp.circular_velocity(r1d)
-    #                 if mcomp._subtype == 'dark_matter':
-    #
-    #                     vhalo1d = np.sqrt(vhalo1d ** 2 + cmpnt_v ** 2)
-    #
-    #                 elif mcomp._subtype == 'baryonic':
-    #
-    #                     vbaryon1d = np.sqrt(vbaryon1d ** 2 + cmpnt_v ** 2)
-    #
-    #                 elif mcomp._subtype == 'combined':
-    #
-    #                     raise ValueError('Adiabatic contraction cannot be turned on when'
-    #                                      'using a combined baryonic and halo mass model!')
-    #
-    #                 else:
-    #                     raise TypeError("{} mass model subtype not recognized"
-    #                                     " for {} component. Only 'dark_matter'"
-    #                                     " or 'baryonic' accepted.".format(mcomp._subtype, cmp))
-    #
-    #
-    #         converged = np.zeros(len(r1d), dtype=bool)
-    #         for i in range(len(r1d)):
-    #             try:
-    #                 result = scp_opt.newton(_adiabatic, r1d[i] + 1.,
-    #                                     args=(r1d[i], vhalo1d, r1d, vbaryon1d[i]),
-    #                                     maxiter=200)
-    #                 converged[i] = True
-    #             except:
-    #                 result = r1d[i]
-    #                 converged[i] = False
-    #
-    #             # ------------------------------------------------------------------
-    #             # HACK TO FIX WEIRD AC: If too weird: toss it...
-    #             if ('adiabatic_contract_modify_small_values' in self.__dict__.keys()):
-    #                 if self.adiabatic_contract_modify_small_values:
-    #                     if ((result < 0.) | (result > 5*max(r1d))):
-    #                         #print("tossing, mvir={}".format(model.components['halotmp'].mvirial.value))
-    #                         result = r1d[i]
-    #                         converged[i] = False
-    #             # ------------------------------------------------------------------
-    #
-    #             rprime_all_1d[i] = result
-    #
-    #
-    #         vhalo_adi_interp_1d = scp_interp.interp1d(r1d, vhalo1d, fill_value='extrapolate', kind='linear')   # linear interpolation
-    #
-    #         # Just calculations:
-    #         if converged.sum() < len(r1d):
-    #             if converged.sum() >= 0.9 *len(r1d):
-    #                 rprime_all_1d = rprime_all_1d[converged]
-    #                 r1d = r1d[converged]
-    #
-    #         vhalo_adi_1d = vhalo_adi_interp_1d(rprime_all_1d)
-    #
-    #         vhalo_adi_interp_map_3d = scp_interp.interp1d(r1d, vhalo_adi_1d, fill_value='extrapolate', kind='linear')
-    #
-    #         vhalo_adi = vhalo_adi_interp_map_3d(r)
-    #
-    #         vel = np.sqrt(vhalo_adi ** 2 + vbaryon ** 2)
-    #
-    #     else:
-    #         vel = np.sqrt(vhalo ** 2 + vbaryon ** 2)
-    #
-    #     if compute_dm:
-    #         if self.adiabatic_contract:
-    #             return vel, vhalo_adi
-    #         else:
-    #             return vel, vhalo
-    #     else:
-    #         return vel
-
-
     def apply_adiabatic_contract(self, model, r, vbaryon_sq, vhalo_sq,
-                                 compute_dm=False,
-                                 return_vsq=False,
-                                 model_key_re=['disk+bulge', 'r_eff_disk'],
+                                 compute_dm=False, return_vsq=False,
+                                 model_aperture_r=config._model_aperture_r,
                                  step1d = 0.2):
         """
         Function that applies adiabatic contraction to a ModelSet
@@ -292,10 +145,10 @@ class KinematicOptions:
         return_vsq : bool
             If True, return square velocities instead of taking sqrt.
 
-        model_key_re : list
-            Two element list which contains the name of the model component
-            and parameter to use for the effective radius.
-            Default is ['disk+bulge', 'r_eff_disk'].
+        model_aperture_r : function
+            Function that takes the model set as input and returns the aperture radius (in kpc).
+            The default returns the disk effective radius
+            (i.e., self.components['disk+bulge'].__getattribute__['r_eff_disk'].value )
 
         step1d : float
             Step size in kpc to use during adiabatic contraction calculation
@@ -319,12 +172,13 @@ class KinematicOptions:
                 rmaxin = r.max()
             except:
                 rmaxin = r
-            # Get reff:
-            comp = model.components.__getitem__(model_key_re[0])
-            param_i = comp.param_names.index(model_key_re[1])
-            r_eff = comp.parameters[param_i]
 
-            rmax_calc = max(5.* r_eff, rmaxin)
+            try:
+                r_ap = model_aperture_r(model)
+            except:
+                r_ap = 0.
+
+            rmax_calc = max(5.* r_ap, rmaxin)
 
             # Wide enough radius range for full calculation -- out to 5*Reff, at least
             r1d = np.arange(step1d, np.ceil(rmax_calc/step1d)*step1d+ step1d, step1d, dtype=np.float64)


### PR DESCRIPTION
Only used for blobs or determining apertures for AC calculation or saved profile ascii files.