### PR TITLE
Bugfix: aperture partial pixel coverage

### DIFF
--- a/dysmalpy/aperture_classes.py
+++ b/dysmalpy/aperture_classes.py
@@ -225,7 +225,7 @@ class EllipAperture(Aperture):
 
                 # define shapely object:
                 circtmp = Point((0,0)).buffer(1)
-                aper_ell = shply_affinity.scale(circtmp, int(self.pix_perp), int(self.pix_parallel))
+                aper_ell = shply_affinity.scale(circtmp, self.pix_perp, self.pix_parallel)
 
 
                 for (whc_y, whc_x) in zip(*wh_calc):

--- a/dysmalpy/fitting_wrappers/setup_gal_models.py
+++ b/dysmalpy/fitting_wrappers/setup_gal_models.py
@@ -2191,11 +2191,6 @@ def setup_basic_aperture_types(obs=None, params=None, extra=''):
     else:
         pix_parallel = None
 
-    if ('pix_length'+extra in params.keys()):
-        pix_length=params['pix_length'+extra]
-    else:
-        pix_length = None
-
 
     if ('partial_weight'+extra in params.keys()):
         partial_weight = params['partial_weight'+extra]
@@ -2219,7 +2214,7 @@ def setup_basic_aperture_types(obs=None, params=None, extra=''):
                     slit_pa=obs.instrument.slit_pa,
                     slit_width=obs.instrument.slit_width,
                     pix_perp=pix_perp, pix_parallel=pix_parallel,
-                    pix_length=pix_length, partial_weight=partial_weight)
+                    partial_weight=partial_weight)
 
 
     return apertures

--- a/dysmalpy/utils_io.py
+++ b/dysmalpy/utils_io.py
@@ -889,7 +889,6 @@ def write_1d_obs_finer_scale(obs=None, model=None, dscale=None, fname=None,
                     aper_centers = aper_centers_interp,
                     aperture_radius=1.,
                     pix_perp=pix_perp_interp, pix_parallel=pix_parallel_interp,
-                    pix_length=None,
                     slit_pa=slit_pa,
                     partial_weight=obs.instrument.apertures.apertures[0].partial_weight)
     elif profile1d_type == 'circ_ap_cube':
@@ -898,7 +897,6 @@ def write_1d_obs_finer_scale(obs=None, model=None, dscale=None, fname=None,
                     aper_centers = aper_centers_interp,
                     aperture_radius=aperture_radius,
                     pix_perp=None, pix_parallel=None,
-                    pix_length=None,
                     slit_pa=slit_pa,
                     partial_weight=obs.instrument.apertures.apertures[0].partial_weight)
     elif profile1d_type == 'circ_ap_pv':
@@ -907,7 +905,6 @@ def write_1d_obs_finer_scale(obs=None, model=None, dscale=None, fname=None,
                     aper_centers = aper_centers_interp,
                     aperture_radius=aperture_radius,
                     pix_perp=None, pix_parallel=None,
-                    pix_length=None,
                     slit_pa=slit_pa, slit_width=obs.instrument.slit_width)
     else:
         do_extract = False

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -146,10 +146,10 @@ class TestFittingWrappers:
                                     params['fit_method'].strip().lower())
         results = fw_utils_io.read_results_ascii_file(fname=f_ascii_machine)
 
-        dict_bf_values = {'disk+bulge': {'total_mass': 10.6943,
-                                         'r_eff_disk': 2.9896},
-                          'halo': {'fdm': 0.2798},
-                          'dispprof_LINE': {'sigma0': 38.2089}}        
+        dict_bf_values = {'disk+bulge': {'total_mass': 10.7218,
+                                         'r_eff_disk': 3.2576},
+                          'halo': {'fdm': 0.2888},
+                          'dispprof_LINE': {'sigma0': 37.9097}}        
 
         # Check that best-fit values are the same
         check_bestfit_values(results, dict_bf_values, fit_method=params['fit_method'], ndim=1)


### PR DESCRIPTION
Fix big in how partial pixel coverage is implemented (for EllipticalAperture and subclasses). Update test functions.
Also remove some lingering aperture pix_length references