### PR TITLE
Add EmpiricalPSF class

### DIFF
--- a/dysmalpy/instrument.py
+++ b/dysmalpy/instrument.py
@@ -20,7 +20,8 @@ import astropy.units as u
 import astropy.constants as c
 from radio_beam import Beam as _RBeam
 
-__all__ = ["Instrument", "GaussianBeam", "DoubleBeam", "Moffat", "LSF"]
+__all__ = ["Instrument", "GaussianBeam", "DoubleBeam",
+           "Moffat", "EmpiricalPSF", "LSF"]
 
 # CONSTANTS
 sig_to_fwhm = 2.*np.sqrt(2.*np.log(2.))
@@ -47,15 +48,10 @@ class Instrument:
 
     Parameters
     ----------
-    beam : 2D array, `~dysmalpy.instrument.GaussianBeam`, `~dysmalpy.instrument.DoubleBeam`, or `~dysmalpy.instrument.Moffat`
-           Object describing the PSF of the instrument
-
-    beam_type : {`'analytic'`, `'empirical'`}
-
-        * `'analytic'` implies the beam is one of the provided beams in `dysmalpy`.
-
-        * `'empirical'` implies the provided beam is a 2D array that describes
-            the convolution kernel.
+    beam : 2D array, 
+           `~dysmalpy.instrument.GaussianBeam`, `~dysmalpy.instrument.DoubleBeam`, 
+           `~dysmalpy.instrument.Moffat`, or `~dysmalpy.instrument.EmpiricalPSF`
+           Object describing the PSF of the instrument.
 
     lsf : LSF object
           Object describing the line spread function of the instrument
@@ -83,7 +79,7 @@ class Instrument:
            
     """
 
-    def __init__(self, beam=None, beam_type=None, lsf=None, pixscale=None,
+    def __init__(self, beam=None, lsf=None, pixscale=None,
                  spec_type='velocity', spec_start=-1000*u.km/u.s,
                  spec_step=10*u.km/u.s, nspec=201,
                  line_center=None,
@@ -93,7 +89,14 @@ class Instrument:
                  integrate_cube=True, slit_width=None, slit_pa=None,
                  fov=None,
                  ndim=None,
-                 name='Instrument'):
+                 name='Instrument',
+                 **kwargs):
+        if getattr(kwargs, "beam_type", None) is not None:
+            logger.warning(
+                "Instrument no longer takes a kwarg 'beam_type'. " \
+                "Empirical PSFs should now be specified using the " \
+                "`EmpiricalPSF` class."
+            )
 
         self.name = name
         self.ndim = ndim
@@ -102,7 +105,6 @@ class Instrument:
 
         # Case of two beams: analytic and empirical: if beam_type==None, assume analytic
         self.beam = beam
-        self.beam_type = beam_type
         self._beam_kernel = None
         self.lsf = lsf
         self._lsf_kernel = None
@@ -131,7 +133,6 @@ class Instrument:
         self.integrate_cube = integrate_cube
         self.slit_width = slit_width
         self.slit_pa = slit_pa
-
 
 
     def convolve(self, cube, spec_center=None):
@@ -248,29 +249,15 @@ class Instrument:
                           size of the kernel
 
         """
-        if (self.beam_type == 'analytic') | (self.beam_type == None):
 
-            if isinstance(self.beam, GaussianBeam):
-                kernel = self.beam.as_kernel(self.pixscale, support_scaling=support_scaling)
-                kern2D = kernel.array
-            else:
-                kernel = self.beam.as_kernel(self.pixscale, support_scaling=support_scaling)
+        self._validate_same_pixscales()
 
-            if isinstance(self.beam, DoubleBeam):
-                kern2D = kernel
-            elif isinstance(self.beam, Moffat):
-                kern2D = kernel
+        kernel = self.beam.as_kernel(self.pixscale, support_scaling=support_scaling)
 
-        elif self.beam_type == 'empirical':
-            if len(self.beam.shape) == 1:
-                raise ValueError("1D beam/PSF not currently supported")
-
-            kern2D = self.beam.copy()
-
-            kern2D[~np.isfinite(kern2D)] = 0.               # Replace NaNs/non-finite with zero
-            kern2D[kern2D<0.] = 0.                          # Replace < 0 with zero:
-
-            kern2D /= np.sum(kern2D[np.isfinite(kern2D)])   # need to normalize
+        if isinstance(self.beam, GaussianBeam):
+            kern2D = kernel.array
+        else:
+            kern2D = kernel
 
         kern3D = np.zeros(shape=(1, kern2D.shape[0], kern2D.shape[1],))
         kern3D[0, :, :] = kern2D
@@ -319,14 +306,12 @@ class Instrument:
 
     @beam.setter
     def beam(self, new_beam):
-        if isinstance(new_beam, GaussianBeam) | isinstance(new_beam, Moffat) | isinstance(new_beam, DoubleBeam):
-            self._beam = new_beam
-        elif new_beam is None:
-            self._beam = None
-        else:
-            raise TypeError("Beam must be an instance of "
-                            "instrument.GaussianBeam, instrument.Moffat, or instrument.DoubleBeam")
+        self._validate_beam(new_beam)
+        self._beam = new_beam
 
+        # Reset stashed kernel:
+        self._beam_kernel = None
+        
     @property
     def lsf(self):
         return self._lsf
@@ -335,6 +320,9 @@ class Instrument:
     def lsf(self, new_lsf):
         self._lsf = new_lsf
 
+        # Reset stashed kernel:
+        self._lsf_kernel = None
+        
     @property
     def pixscale(self):
         return self._pixscale
@@ -352,6 +340,56 @@ class Instrument:
             else:
                 raise u.UnitsError("pixscale not in equivalent units to "
                                    "arcseconds.")
+            
+        # Reset stashed kernels:
+        self._clear_kernels()
+        
+    def _validate_beam(self, new_beam):
+
+        _allowed_beam_types = (GaussianBeam, Moffat,
+                               DoubleBeam, EmpiricalPSF)
+
+        # ----------------
+        # ALLOW FOR BACKWARDS COMPATIBILITY FOR NOW!
+        if not (
+            isinstance(new_beam, _allowed_beam_types)
+            | (new_beam is None)
+        ):
+            if isinstance(new_beam, np.ndarray):
+                logger.warning(
+                    "To use empirical PSFs, please pass "
+                    "an EmpiricalPSF instance!\n"
+                    "***** Assuming the input 2D array has " 
+                    "the same pixel scale as the instrument!! *****"
+                )
+                new_beam = EmpiricalPSF(
+                    psf_array=new_beam,
+                    pixscale=self.pixscale
+                )
+        # ----------------
+
+        if not (
+            isinstance(new_beam, _allowed_beam_types)
+            | (new_beam is None)
+        ):
+            emsg = f"Invalid beam: {type(new_beam)}"
+            emsg += "Beam must be an instance of "
+            for i, bt in enumerate(_allowed_beam_types):
+                if i == 0:
+                    emsg += f"instrument.{bt.__name__}"
+                else:
+                    emsg += f", instrument.{bt.__name__}"
+            raise TypeError(emsg)
+
+    def _validate_same_pixscales(self):
+        # If beam is an EmpiricalPSF, check that instrument and beam
+        # have the same pixscales.
+        if isinstance(self.beam, EmpiricalPSF):
+            if self.pixscale != self.beam.pixscale:
+                raise ValueError(
+                    "Cannot set kernel, as EmpiricalPSF beam "
+                    "does not have same pixscale as instrument!"
+                )
 
     @property
     def spec_step(self):
@@ -490,6 +528,9 @@ class DoubleBeam:
         kernel_total = 10. * (kernel1.array * self._scale1 / np.sum(kernel1.array) +
                               kernel2.array * self._scale2 / np.sum(kernel2.array))
 
+        # Normalize total kernel:
+        kernel_total /= np.sum(kernel_total[np.isfinite(kernel_total)]) 
+
         return kernel_total
 
     def __deepcopy__(self, memo):
@@ -617,11 +658,96 @@ class Moffat(object):
 
         kernel = (self.beta-1.)/(np.pi * alpha**2) * np.power( (1. + (r/alpha)**2 ), -1.*self.beta )
 
+        # Normalize kernel:
+        kernel /= np.sum(kernel[np.isfinite(kernel)]) 
+
         return kernel
+    
+
+class EmpiricalPSF(object):
+    """
+    EmpiricalPSF beam class.
+
+    Parameters
+    ----------
+    psf_array : 2D array
+                2D array containing the empirical PSF.
+    pixscale : float or `~astropy.units.Quantity`
+            Angular scale of the ePSF pixels (square pixels are assumed).
+            If no units are used, arcseconds are assumed.
+    """
+    def __init__(self, psf_array=None, pixscale=None):
+
+        self.psf_array = psf_array
+        self.pixscale = pixscale
+
+    @property
+    def psf_array(self):
+        return self._psf_array
+
+    @psf_array.setter
+    def psf_array(self, value):
+        if value is None:
+            raise ValueError('Must specify "psf_array" to use an EmpiricalPSF!')
+        
+        # Ensure input is np.ndarray:
+        value = np.array(value)
+        if len(value.shape) != 2:
+            raise ValueError(f"Empirical PSF must be 2D! psf_array.shape={value.shape}")
+
+        self._psf_array = value
+
+    @property
+    def pixscale(self):
+        return self._pixscale
+
+    @pixscale.setter
+    def pixscale(self, value):
+        if value is None:
+            raise ValueError('"pixscale" must be specified for EmpiricalPSFs!')
+        
+        if not isinstance(value, u.Quantity):
+            logger.warning("No units on pixscale. Assuming arcseconds.")
+            self._pixscale = value*u.arcsec
+        else:
+            if (u.arcsec).is_equivalent(value):
+                self._pixscale = value
+            else:
+                raise u.UnitsError("pixscale not in equivalent units to "
+                                   "arcseconds.")
+            
+        # elif self.beam_type == 'empirical':
+        #     if len(self.beam.shape) == 1:
+        #         raise ValueError("1D beam/PSF not currently supported")
+
+    def as_kernel(self, pixscale, **kwargs):
+        """
+        Return the Empirical PSF array as the kernel.
+
+        Parameters
+        ----------
+        pixscale : `~astropy.units.Quantity`
+                   Pixel scale of image that will be convolved
+
+        Returns
+        -------
+        kernel : 2D array
+                 Convolution kernel for the Moffat PSF
+        """
+        kernel = self.psf_array.copy()
+
+        kernel[~np.isfinite(kernel)] = 0.               # Replace NaNs/non-finite with zero
+        kernel[kernel<0.] = 0.                          # Replace < 0 with zero:
+
+        kernel /= np.sum(kernel[np.isfinite(kernel)])   # need to normalize
+
+        return kernel
+
 
 class LSF(u.Quantity):
     """
-    An object to handle line spread functions.
+    An object to handle line spread functions, 
+    assuming a Gaussian LSF shape.
     """
 
     def __new__(cls, dispersion=None, default_unit=u.km/u.s, meta=None):

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,321 @@
+# coding=utf8
+# Copyright (c) MPE/IR-Submm Group. See LICENSE.rst for license information. 
+#
+# Testing of DYSMALPY model (component) calculations
+
+import pytest
+
+import numpy as np
+import astropy.units as u
+
+from dysmalpy.fitting_wrappers import utils_io as fw_utils_io
+
+from dysmalpy import galaxy, models, parameters, instrument, observation
+
+import logging
+logger = logging.getLogger('DysmalPy')
+logger.setLevel(logging.DEBUG)
+
+class HelperSetups(object):
+
+    def __init__(self):
+        self.z = 1.613
+        self.name = 'GS4_43501'
+
+    def setup_diskbulge(self):
+        # Baryonic Component: Combined Disk+Bulge
+        total_mass =    11.0    # M_sun
+        bt =            0.3     # Bulge-Total ratio
+        r_eff_disk =    5.0     # kpc
+        n_disk =        1.0
+        invq_disk =     5.0
+        r_eff_bulge =   1.0     # kpc
+        n_bulge =       4.0
+        invq_bulge =    1.0
+        noord_flat =    True    # Switch for applying Noordermeer flattening
+
+        # Fix components
+        bary_fixed = {'total_mass': False,
+                      'r_eff_disk': False,
+                      'n_disk': True,
+                      'r_eff_bulge': True,
+                      'n_bulge': True,
+                      'bt': False}
+
+        # Set bounds
+        bary_bounds = {'total_mass': (10, 13),
+                       'r_eff_disk': (1.0, 30.0),
+                       'n_disk': (1, 8),
+                       'r_eff_bulge': (1, 5),
+                       'n_bulge': (1, 8),
+                       'bt': (0, 1)}
+
+        bary = models.DiskBulge(total_mass=total_mass, bt=bt,
+                                r_eff_disk=r_eff_disk, n_disk=n_disk,
+                                invq_disk=invq_disk,
+                                r_eff_bulge=r_eff_bulge, n_bulge=n_bulge,
+                                invq_bulge=invq_bulge,
+                                noord_flat=noord_flat,
+                                name='disk+bulge',
+                                fixed=bary_fixed, bounds=bary_bounds,
+                                gas_component='total')
+
+        bary.r_eff_disk.prior = parameters.BoundedGaussianPrior(center=5.0, stddev=1.0)
+
+        return bary
+
+    def setup_NFW(self):
+        # NFW Halo component
+        mvirial = 12.0
+        conc = 5.0
+        fdm = 0.5
+        halo_fixed = {'mvirial': False,
+                      'conc': True,
+                      'fdm': False}
+
+        halo_bounds = {'mvirial': (10, 13),
+                       'conc': (1, 20),
+                       'fdm': (0., 1.)}
+
+        halo = models.NFW(mvirial=mvirial, conc=conc, fdm=fdm,z=self.z,
+                          fixed=halo_fixed, bounds=halo_bounds, name='halo')
+
+        halo.fdm.tied = fw_utils_io.tie_fdm
+        halo.mvirial.prior = parameters.BoundedGaussianPrior(center=11.5, stddev=0.5)
+
+        return halo
+
+    def setup_const_dispprof(self):
+        # Dispersion profile
+        sigma0 = 39.   # km/s
+        disp_fixed = {'sigma0': False}
+        disp_bounds = {'sigma0': (10, 200)}
+
+        disp_prof = models.DispersionConst(sigma0=sigma0, fixed=disp_fixed,
+                                                  bounds=disp_bounds, name='dispprof',
+                                                  tracer='halpha')
+
+        return disp_prof
+
+    def setup_zheight_prof(self):
+        # z-height profile
+        sigmaz = 0.9   # kpc
+        zheight_fixed = {'sigmaz': False}
+
+        zheight_prof = models.ZHeightGauss(sigmaz=sigmaz, name='zheightgaus', fixed=zheight_fixed)
+        zheight_prof.sigmaz.tied = fw_utils_io.tie_sigz_reff
+
+        return zheight_prof
+
+    def setup_geom(self):
+        # Geometry
+        inc = 62.     # degrees
+        pa = 142.     # degrees, blue-shifted side CCW from north
+        xshift = 0    # pixels from center
+        yshift = 0    # pixels from center
+
+        geom_fixed = {'inc': False,
+                      'pa': True,
+                      'xshift': True,
+                      'yshift': True}
+
+        geom_bounds = {'inc': (0, 90),
+                       'pa': (90, 180),
+                       'xshift': (0, 4),
+                       'yshift': (-10, -4)}
+
+        geom = models.Geometry(inc=inc, pa=pa, xshift=xshift, yshift=yshift,
+                               fixed=geom_fixed, bounds=geom_bounds, name='geom',
+                               obs_name='halpha_1D')
+
+        return geom
+
+    def setup_fullmodel(self, adiabatic_contract=False,
+                pressure_support=True, pressure_support_type=1, instrument=None):
+        # Initialize the Galaxy, Observation, Instrument, and Model Set
+        gal = galaxy.Galaxy(z=self.z, name=self.name)
+        obs = observation.Observation(name='halpha_1D', tracer='halpha')
+        obs.mod_options.oversample = 3
+        obs.mod_options.zcalc_truncate = True
+
+        mod_set = models.ModelSet()
+
+        bary = self.setup_diskbulge()
+        halo = self.setup_NFW()
+        disp_prof = self.setup_const_dispprof()
+        zheight_prof = self.setup_zheight_prof()
+        geom = self.setup_geom()
+        dimming = self.setup_constant_dimming()
+
+        # Add all of the model components to the ModelSet
+        mod_set.add_component(bary, light=True)
+        mod_set.add_component(halo)
+        mod_set.add_component(disp_prof)
+        mod_set.add_component(zheight_prof)
+        mod_set.add_component(geom)
+
+        ## Set some kinematic options for calculating the velocity profile
+        # pressure_support_type: 1 / Exponential, self-grav [Burkert+10]
+        #                        2 / Exact nSersic, self-grav
+        #                        3 / Pressure gradient
+        mod_set.kinematic_options.adiabatic_contract = adiabatic_contract
+        mod_set.kinematic_options.pressure_support = pressure_support
+        mod_set.kinematic_options.pressure_support_type = pressure_support_type
+
+        mod_set.dimming = dimming
+
+        # Add the model set and instrument to the Galaxy
+        gal.model = mod_set
+
+        if instrument:
+            obs.instrument = instrument
+
+        # Add the observation to the Galaxy
+        gal.add_observation(obs)
+
+        return gal
+
+
+    def setup_instrument(self, beam=None, lsf=None):
+        inst = instrument.Instrument()
+
+        # Set up the instrument
+        pixscale = 0.125*u.arcsec                # arcsec/pixel
+        fov = [33, 33]                           # (nx, ny) pixels
+        spec_type = 'velocity'                   # 'velocity' or 'wavelength'
+        spec_start = -1000*u.km/u.s              # Starting value of spectrum
+        spec_step = 10*u.km/u.s                  # Spectral step
+        nspec = 201                              # Number of spectral pixels
+
+        inst.pixscale = pixscale
+        inst.fov = fov
+        inst.spec_type = spec_type
+        inst.spec_step = spec_step
+        inst.spec_start = spec_start
+        inst.nspec = nspec
+
+        # Extraction information
+        inst.ndim = 3                            # Dimensionality of data
+        inst.moment = False                      # For 1D/2D data, if True then velocities and dispersion calculated from moments
+                                                 # Default is False, meaning Gaussian extraction used
+
+        # Set the beam kernel so it doesn't have to be calculated every step
+        if beam is not None:
+            inst.beam = beam
+            inst.set_beam_kernel()
+        if lsf is not None:
+            inst.lsf = lsf
+            inst.set_lsf_kernel()
+
+        return inst
+    
+    def setup_lsf(self, sig_inst = 45*u.km/u.s):
+        # Instrumental spectral resolution
+        return instrument.LSF(sig_inst)
+    
+    def setup_gaussian_beam(self, beamsize = 0.55*u.arcsec):
+        # FWHM of beam
+        return instrument.GaussianBeam(major=beamsize)
+
+    def setup_double_beam(
+        self,
+        major1 = 0.55*u.arcsec, 
+        major2=0.25*u.arcsec,
+        scale2 = 0.2
+    ):
+        # FWHM of beam
+        return instrument.DoubleBeam(
+            major1=major1,
+            major2=major2,
+            scale2=scale2
+        )
+    
+    def setup_moffat_beam(self, major_fwhm=0.55*u.arcsec, beta=3):
+        return instrument.Moffat(
+             major_fwhm=major_fwhm,
+             beta=beta,
+        )
+    
+    def setup_empirical_beam(self, pixscale=0.125*u.arcsec):
+        gaus = self.setup_gaussian_beam()
+        # Upscale to check normalization
+        kernel = gaus.as_kernel(pixscale).array * 5
+
+        return instrument.EmpiricalPSF(
+            psf_array=kernel,
+            pixscale=pixscale
+        )
+
+
+class TestInstrument:
+    helper = HelperSetups()
+
+    def test_gaussian_beam(self):
+        beam = self.helper.setup_gaussian_beam()
+        lsf = self.helper.setup_lsf()
+
+        inst = self.helper.setup_instrument(beam=beam, lsf=lsf)
+        
+        assert inst._beam_kernel is not None
+        assert inst._lsf_kernel is not None
+
+        assert np.isclose(np.sum(inst._beam_kernel), 1)
+
+    def test_double_beam(self):
+        beam = self.helper.setup_double_beam()
+        lsf = self.helper.setup_lsf()
+
+        inst = self.helper.setup_instrument(beam=beam, lsf=lsf)
+        
+        assert inst._beam_kernel is not None
+        assert inst._lsf_kernel is not None
+
+        assert np.isclose(np.sum(inst._beam_kernel), 1)
+
+    def test_moffat_beam(self):
+        beam = self.helper.setup_moffat_beam()
+        lsf = self.helper.setup_lsf()
+
+        inst = self.helper.setup_instrument(beam=beam, lsf=lsf)
+        
+        assert inst._beam_kernel is not None
+        assert inst._lsf_kernel is not None
+
+        assert np.isclose(np.sum(inst._beam_kernel), 1)
+
+    def test_empirical_beam(self):
+        beam = self.helper.setup_empirical_beam()
+        lsf = self.helper.setup_lsf()
+
+        inst = self.helper.setup_instrument(beam=beam, lsf=lsf)
+        
+        assert inst._beam_kernel is not None
+        assert inst._lsf_kernel is not None
+
+        assert np.isclose(np.sum(inst._beam_kernel), 1)
+
+    def test_empirical_beam_pixscale_mismatch(self):
+        beam = self.helper.setup_empirical_beam(pixscale=0.1*u.arcsec)
+        lsf = self.helper.setup_lsf()
+
+        with pytest.raises(ValueError) as excinfo:
+            _ = self.helper.setup_instrument(beam=beam, lsf=lsf)
+        estr = "Cannot set kernel, as EmpiricalPSF beam "
+        assert estr in str(excinfo.value)
+        
+
+    def test_no_lsf(self):
+        beam = self.helper.setup_gaussian_beam()
+
+        inst = self.helper.setup_instrument(beam=beam, lsf=None)
+        
+        assert inst._beam_kernel is not None
+        assert inst._lsf_kernel is None
+
+    def test_no_beam(self):
+        lsf = self.helper.setup_lsf()
+        inst = self.helper.setup_instrument(beam=None, lsf=lsf)
+        
+        assert inst._beam_kernel is None
+        assert inst._lsf_kernel is not None
+


### PR DESCRIPTION
Streamline empirical PSF class handling, to provide more clarity in how to use empirical PSFs (fixes #132).

Changes:
* Add EmpiricalPSF class (consistent handling with other beam types)
* Add validation run when setting the beam kernel (eg, invoked when convolving with the beam) that verifies that EmpiricalPSF and Instrument have the same pixscale, and raises an error if not.
* Remove `beam_type` kwarg from Instrument init (add `**kwargs` to silently enable backwards compatibility, and add a note about the new behavior if `beam_type` is passed)
* Add a fallback if `beam` is a 2D np.ndarray, to wrap it in a EmpiricalPSF instance while raising a warning that this is being done, and that the EmpiricalPSF is assumed to have the same pixscale as the instrument.
* Streamline instrument beam validation with internal refactor
* Add tests/test_instruments.py to test instrument creation and kernel calculations.

Other changes:
* Add proper normalization for double beam (total was up to 12!!), moffat PSFs. *